### PR TITLE
Dynamic multus-default-route script

### DIFF
--- a/multus-default-route.sh
+++ b/multus-default-route.sh
@@ -30,26 +30,24 @@ else
    echo "error can't install package $PACKAGE"
    exit 1;
 fi
-############### Number of net* interfaces in a pod ############
-ifcount=$(ip a | grep 'net' | grep 'inet' -v | grep 'netns' -v -c)
-C=1 
+############### Get Multus interface names, number of interfaces attached and set a count variable for conditional loop below  ############
+C=1
+MULTUS_INT_NAMES=$(ip -o -4 addr list | grep -w 'lo\|eth0' -v | awk '{print $2}')
+IF_COUNT=$(ip -o -4 addr list | grep -w 'lo\|eth0' -v -c)
 
-############### Conditional loop to configure route tables for each net* interface ############
-while [[ $C -le $ifcount ]]; do
+############### Conditional loop to configure route tables for each Multus interface ############
+while [[ $C -le $IF_COUNT ]]; do
 		############### STORING VARIABLES ##############################
-	#store ip address of net* as a variable $ip4
-	ip4=$(/sbin/ip -o -4 addr list net$C | awk '{print $4}' | cut -d/ -f1)
+	#Get first interface name from MULTUS_INT_NAMES variable
+	CURRENT_INT=$(echo $MULTUS_INT_NAMES | awk -v C=$C '{print $C}')
+	#store ip address of current interface as a variable $ip4
+	ip4=$(/sbin/ip -o -4 addr list $CURRENT_INT | awk '{print $4}' | cut -d/ -f1)
 
-	#store ip subnet of net1 as variable $ipsub
-	ipsub=$(ip route | grep net$C | awk '{print $1}')
+	#store network ID of current interface as variable $ipsub
+	ipsub=$(ip route | grep $CURRENT_INT | awk '{print $1}')
 
 	#store subnet without the "/"  as variable $subval
-	#subval=$(route -n | grep -w 'U' | awk '{print $1}')
-	#subval=$(route -n | grep -w 'U' | sort -r | awk '{print $1}')
-	#netsubval=$(echo $subval | cut -f $C -d " ")
-	
-	# Changed grep pattern for subnet value to fix errors with incorrect value being taken over by previous commands.
-	netsubval=$(route -n | grep -w net$C | awk '{print $1}')   
+	netsubval=$(route -n | grep -w $CURRENT_INT | awk '{print $1}')
 
 	#Since multus does not push the Gateway for net1 into the routing table, I was able to acquire the GW by taking the $netsubval viariable and adding +1 to the last octet, storing in variable $gw
 	#Note the below command assumes the GW is the 1st IP after the network ID. This assumtion is made specific to the project CIQ. Eg if your network is 10.46.90.224/27 , the GW will be 10.46.90.225 (10.46.90.224+1).
@@ -59,8 +57,8 @@ while [[ $C -le $ifcount ]]; do
 	################ CONFIGURE ROUTING #############################
 	# Add route tables (t1,t2,t3...tn) if not present in the rt_table with sequence (100,101,102...n) 
 	grep "t$C" /etc/iproute2/rt_tables || echo 10$C t$C >> /etc/iproute2/rt_tables
-	ip route show table t$C | grep $ip4 || ip route add $ipsub dev net$C src $ip4 table t$C
-	ip route show table t$C | grep default ||ip route add table t$C default via $gw dev net$C
+	ip route show table t$C | grep $ip4 || ip route add $ipsub dev $CURRENT_INT src $ip4 table t$C
+	ip route show table t$C | grep default ||ip route add table t$C default via $gw dev $CURRENT_INT
 	ip rule add table t$C from $ip4
 	sysctl net.ipv4.conf.default.arp_filter=1
 	C=$((C + 1))


### PR DESCRIPTION
Till now, we were using script which assumed the default multus interface names (net1,net2,net3, etc.). During Multus set up on the k8s cluster, a user can choose to create custom names for multus interfaces and in such cases, the previous script would fail as net interfaces are statically defined throughout. This script is enhanced to overcome such scenarios. It will automatically pick all the interface names except the default 'lo' and 'eth0' and works it way out accordingly.